### PR TITLE
Rename Artisan command `lang:parse-to-i18Next` to `lang:to-i18next`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0] - 2025-08-01
+### Changed
+- **Breaking:** Renamed Artisan command from `lang:parse-to-i18Next` to `lang:to-i18next` for improved consistency and readability.
+
+### Migration Notes
+Replace any usage of:
+```bash
+  php artisan lang:parse-to-i18Next
+```
+with:
+```bash
+  php artisan lang:to-i18next
+```
+
 ## [1.1.0] - 2025-08-01
 ### Added
 - **Version tracking system:**

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package parses your <a href="https://laravel.com/docs/12.x/localization" ta
     - A unique hash for each locale’s translation files
     - A `last_updated` timestamp
     - Useful for cache invalidation and detecting translation updates
-- Artisan command: `lang:parse-to-i18Next {locale?}`
+- Artisan command: `lang:to-i18next {locale?}`
 ```
 
 ---
@@ -32,9 +32,9 @@ composer require ozner-omali/laravel-to-i18next-lang-parser
 ## 🔧 Usage
 ```
 1. Export all locales
-    php artisan lang:parse-to-i18Next
+    php artisan lang:to-i18next
 2. Export a specific locale
-    php artisan lang:parse-to-i18Next es
+    php artisan lang:to-i18next es
 ```
 
 This will generate: \

--- a/src/Console/ParseLangToI18NextCommand.php
+++ b/src/Console/ParseLangToI18NextCommand.php
@@ -14,7 +14,7 @@ class ParseLangToI18NextCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'lang:parse-to-i18Next {locale?}';
+    protected $signature = 'lang:to-i18next {locale?}';
 
     /**
      * The console command description.


### PR DESCRIPTION
Rename Artisan command `lang:parse-to-i18Next` to `lang:to-i18next`